### PR TITLE
Add --seconds parameter to specify video duration

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -85,6 +85,7 @@ func newGenerateCommand() *ffcli.Command {
 	fs.IntVar(&cfg.Height, "height", 0, "output video height (optional)")
 	fs.BoolVar(&cfg.Explore, "explore", false, "explore mode (optional)")
 	fs.BoolVar(&cfg.LastFrame, "last-frame", false, "use source image as the last frame (optional)")
+	fs.IntVar(&cfg.Seconds, "seconds", 10, "duration of the video in seconds (optional)")
 
 	return &ffcli.Command{
 		Name:       cmd,
@@ -120,6 +121,7 @@ func newExtendCommand() *ffcli.Command {
 	fs.BoolVar(&cfg.Upscale, "upscale", false, "upscale frames (optional)")
 	fs.BoolVar(&cfg.Watermark, "watermark", false, "add watermark (optional)")
 	fs.BoolVar(&cfg.Explore, "explore", false, "explore mode (optional)")
+	fs.IntVar(&cfg.Seconds, "seconds", 2, "duration of the video in seconds (optional)")
 
 	return &ffcli.Command{
 		Name:       cmd,

--- a/pkg/cmd/extend/extend.go
+++ b/pkg/cmd/extend/extend.go
@@ -29,6 +29,7 @@ type Config struct {
 	Upscale     bool
 	Watermark   bool
 	Explore     bool
+	Seconds     int
 }
 
 // Run generates a video from an image and a text prompt.
@@ -106,6 +107,7 @@ func Run(ctx context.Context, cfg *Config) error {
 			Watermark:   cfg.Watermark,
 			Extend:      false,
 			ExploreMode: cfg.Explore,
+			Seconds:     cfg.Seconds,
 		})
 		if err != nil {
 			return fmt.Errorf("vidai: couldn't generate video: %w", err)

--- a/pkg/cmd/generate/generate.go
+++ b/pkg/cmd/generate/generate.go
@@ -32,6 +32,7 @@ type Config struct {
 	Height      int
 	Explore     bool
 	LastFrame   bool
+	Seconds     int
 }
 
 // Run generates a video from an image and a text prompt.
@@ -89,6 +90,7 @@ func Run(ctx context.Context, cfg *Config) error {
 		Height:      cfg.Height,
 		ExploreMode: cfg.Explore,
 		LastFrame:   cfg.LastFrame,
+		Seconds:     cfg.Seconds,
 	})
 	if err != nil {
 		return fmt.Errorf("vidai: couldn't generate video: %w", err)
@@ -104,6 +106,7 @@ func Run(ctx context.Context, cfg *Config) error {
 			Upscale:     cfg.Upscale,
 			Watermark:   cfg.Watermark,
 			Extend:      true,
+			Seconds:     cfg.Seconds,
 		})
 		if err != nil {
 			return fmt.Errorf("vidai: couldn't extend video: %w", err)

--- a/pkg/runway/runway.go
+++ b/pkg/runway/runway.go
@@ -357,6 +357,7 @@ type GenerateRequest struct {
 	Height      int
 	ExploreMode bool
 	LastFrame   bool
+	Seconds     int
 }
 
 type Error struct {
@@ -466,7 +467,7 @@ func (c *Client) Generate(ctx context.Context, cfg *GenerateRequest) (*Generatio
 				AssetGroupName string      `json:"assetGroupName"`
 				ExploreMode    bool        `json:"exploreMode"`
 			}{
-				Seconds: 4,
+				Seconds: cfg.Seconds,
 				Gen2Options: gen2Options{
 					Interpolate:    cfg.Interpolate,
 					Seed:           seed,
@@ -513,7 +514,7 @@ func (c *Client) Generate(ctx context.Context, cfg *GenerateRequest) (*Generatio
 			Internal: false,
 			Options: gen3Options{
 				Name:            name,
-				Seconds:         10,
+				Seconds:         cfg.Seconds,
 				TextPrompt:      cfg.Prompt,
 				Seed:            seed,
 				ExploreMode:     cfg.ExploreMode,


### PR DESCRIPTION
Fixes #8

Add the option to specify the `--seconds` parameter for `img2video`.

* **pkg/cli/cli.go**
  - Add a `--seconds` parameter to the `generate` command.
  - Add a `--seconds` parameter to the `extend` command.

* **pkg/cmd/generate/generate.go**
  - Add a `Seconds` field to the `Config` struct.
  - Parse the `--seconds` parameter and set the `Seconds` field in the `Run` function.

* **pkg/cmd/extend/extend.go**
  - Add a `Seconds` field to the `Config` struct.
  - Parse the `--seconds` parameter and set the `Seconds` field in the `Run` function.

* **pkg/runway/runway.go**
  - Use the `Seconds` field from the `GenerateRequest` struct in the `createGen2TaskRequest` and `createGen3TaskRequest` structures.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/igolaizola/vidai/issues/8?shareId=b5a6cdc4-02f9-4020-a274-ea3db020ad53).